### PR TITLE
Removing `/` that was causing redirect

### DIFF
--- a/app.go
+++ b/app.go
@@ -130,7 +130,7 @@ func (a *App) initializeApiRoutes() {
 	mediaRouter := a.APIRouter.PathPrefix("/media").Subrouter()
 
 	mediaRouter.HandleFunc("/upload", a.loginRequired(a.uploadMediaFile)).Methods("POST")
-	mediaRouter.HandleFunc("/", a.loginRequired(a.getUploadListing)).Methods("GET")
+	mediaRouter.HandleFunc("", a.loginRequired(a.getUploadListing)).Methods("GET")
 	mediaRouter.HandleFunc("/{filename:.+}", a.loginRequired(a.deleteMediaFile)).Methods("DELETE")
 
 }


### PR DESCRIPTION
Trailing slash was causing server to 302 '/api/media' to '/api/media/'. In doing so Safari would strip the 'Authorization' header from the new request.